### PR TITLE
Cat Rain use Web Animation API instead of rAF loop

### DIFF
--- a/main.js
+++ b/main.js
@@ -113,28 +113,19 @@ function createCat() {
     cat.style.top = '-50px';
 
     document.body.appendChild(cat);
-
+    
     // Animate falling
-    let posY = -50;
     let rotation = Math.random() * 360;
     let speedY = 1 + Math.random() * 2;
     let speedRotation = -2 + Math.random() * 4;
-
-    function animate() {
-        posY += speedY;
-        rotation += speedRotation;
-        cat.style.top = posY + 'px';
-        cat.style.transform = `rotate(${rotation}deg)`;
-
-        // Remove when off screen
-        if (posY > window.innerHeight) {
-            cat.remove();
-        } else {
-            requestAnimationFrame(animate);
-        }
-    }
-
-    animate();
+    let distance = window.innerHeight;
+    
+    cat.animate([
+        { top: '-50px', rotate: `${rotation}deg` },
+        { top: `${distance}px`, rotate: `${rotation * speedRotation * 4}deg` },
+    ], {
+        duration: (distance / speedY * 8)
+    }).finished.then(() => cat.remove());
 }
 
 // Create new cats periodically


### PR DESCRIPTION
Uses the Web Animation API for cat rain instead. ([`Element.animate`](https://developer.mozilla.org/en-US/docs/Web/API/Element/animate))

rAF loops run at 120Hz on, well, 120Hz displays, so the cats end up falling and spinning twice as fast.

Now imagine how that feels like on a 240Hz display.

You can fix that by using delta time in the rAF animation loops but there is the Web Animation API which also animates it off the main thread and other good stuff.